### PR TITLE
Min and max should be parsed as floats

### DIFF
--- a/src/js/ngTouchSpin.js
+++ b/src/js/ngTouchSpin.js
@@ -9,8 +9,8 @@ angular.module('jkuri.touchspin', [])
 	};
 
 	var setScopeValues = function (scope, attrs) {
-		scope.min = attrs.min || 0;
-		scope.max = attrs.max || 100;
+		scope.min = parseFloat(Number(attrs.min)) || 0;
+		scope.max = parseFloat(Number(attrs.max)) || 100;
 		scope.step = attrs.step || 1;
 		scope.prefix = attrs.prefix || undefined;
 		scope.postfix = attrs.postfix || undefined;


### PR DESCRIPTION
In order to compare the input number correctly against the configured min and max values, min and max should be parsed as floats. Currently, they are left as string values, which leads to unexpected results when the number consists of more than one digit.

For example, the number 4 is considered to be bigger than the string "30".